### PR TITLE
Fixed numbering system for new posts

### DIFF
--- a/clog/new.sh
+++ b/clog/new.sh
@@ -4,10 +4,10 @@ DT=$(date)
 IFS=''
 INDEX_FILE=index
 
-echo "Title of blog post to create:"
+echo -n "Title of blog post to create: "
 read TITLE
 
-FILE_COUNT=$(ls | wc -l)
+FILE_COUNT=$(( $(ls | grep -e '[0-9+]' | wc -l) + 1 ))
 
 printf "Entry created : %s\n" $FILE_COUNT
 


### PR DESCRIPTION
I changed the file count to consider only numbered files, ignoring the index page and "new.sh". This way the new post filename should match the number of posts.