### PR TITLE
Curl can now follow redirects

### DIFF
--- a/clogs.sh
+++ b/clogs.sh
@@ -17,9 +17,9 @@ print_help () {
 }
 
 check_url () {
-	if curl --output /dev/null --silent --fail -r 0-0 "$CLOG_URL"; then
+	if curl --output /dev/null --silent --fail -L -r 0-0 "$CLOG_URL"; then
 		clear
-		curl -s $CLOG_URL
+		curl -Ls $CLOG_URL
 		echo ""
 		echo ""
 	else


### PR DESCRIPTION
There was a problem with websites that redirects http to https: using just `curl -s` ignores redirects and presents a page with the redirect request instead of the actual clog.
This also created "false positives" when checking for an existing clog.
The changes I made (basically adding a `-L` option) allows to follow redirects: it seems significantly slower when redirecting, but at least it makes things work like they should